### PR TITLE
Scaffolding for multiple UIs and stub of QA UI 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1243,9 +1243,8 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1312,9 +1311,8 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@types/babel__core": {
@@ -1796,9 +1794,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -1853,9 +1850,8 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -2080,9 +2076,8 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/electron-to-chromium": {
@@ -2769,9 +2764,8 @@
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
@@ -3004,9 +2998,8 @@
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -3019,9 +3012,8 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -3076,9 +3068,8 @@
     },
     "node_modules/react-is": {
       "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freebrowse/frontend",
   "private": true,
-  "version": "2.3.1",
+  "version": "2.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/canvas-area.tsx
+++ b/frontend/src/components/canvas-area.tsx
@@ -8,16 +8,17 @@ interface CanvasAreaProps {
   nvInstance: Niivue;
   viewMode: ViewMode;
   onFileUpload: (files: File[]) => Promise<void>;
+  nvCanvasEmptyState?: React.ReactNode;
 }
 
-export default function CanvasArea({ nvInstance, viewMode, onFileUpload }: CanvasAreaProps) {
+export default function CanvasArea({ nvInstance, viewMode, onFileUpload, nvCanvasEmptyState }: CanvasAreaProps) {
   const showUploader = useFreeBrowseStore((s) => s.showUploader);
 
   return (
     <main className="flex-1 min-h-0 overflow-hidden flex flex-col">
       {showUploader ? (
         <div className="flex flex-1 items-center justify-center">
-          <ImageUploader onUpload={onFileUpload} />
+          {nvCanvasEmptyState ?? <ImageUploader onUpload={onFileUpload} />}
         </div>
       ) : (
         <div className="flex flex-1">

--- a/frontend/src/components/freebrowse.tsx
+++ b/frontend/src/components/freebrowse.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef } from "react";
-import { useFreeBrowseStore } from "@/store";
+import { useRef } from "react";
 import { useViewerOptions } from "@/hooks/use-viewer-options";
 import { useLocation } from "@/hooks/use-location";
 import { useVolumes } from "@/hooks/use-volumes";
@@ -9,9 +8,7 @@ import { useSave } from "@/hooks/use-save";
 import { useFileLoading } from "@/hooks/use-file-loading";
 import { Niivue } from "@niivue/niivue";
 import "../App.css";
-import Header from "./header";
-import Footer from "./footer";
-import CanvasArea from "./canvas-area";
+import ViewerShell from "./viewer-shell";
 import Sidebar from "./sidebar";
 import RemoveDialog from "./dialogs/remove-dialog";
 import SaveDialog from "./dialogs/save-dialog";
@@ -27,10 +24,6 @@ const nv = new Niivue({
 });
 
 export default function FreeBrowse() {
-  const sidebarOpen = useFreeBrowseStore((s) => s.sidebarOpen);
-  const footerOpen = useFreeBrowseStore((s) => s.footerOpen);
-  const darkMode = useFreeBrowseStore((s) => s.darkMode);
-
   const nvRef = useRef<Niivue | null>(nv);
 
   // --- Hooks ---
@@ -110,99 +103,85 @@ export default function FreeBrowse() {
     syncDrawingOptionsFromNiivue,
   );
 
-  // Apply dark mode class to document root
-  useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
-  }, [darkMode]);
-
   return (
-    <div className="flex h-full flex-col">
-      <Header nvRef={nvRef} />
-
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex flex-1 flex-col min-h-0">
-          <CanvasArea
-            nvInstance={nv}
-            viewMode={viewerOptions.viewMode}
-            onFileUpload={handleFileUpload}
+    <ViewerShell
+      nvInstance={nv}
+      viewMode={viewerOptions.viewMode}
+      onFileUpload={handleFileUpload}
+      sidebar={
+        <Sidebar
+          nvRef={nvRef}
+          serverlessMode={serverlessMode}
+          onNvdFileSelect={handleNvdFileSelect}
+          onImagingFileSelect={handleImagingFileSelect}
+          onAddMoreFiles={handleAddMoreFiles}
+          onAddSurfaceFiles={handleAddSurfaceFiles}
+          onToggleImageVisibility={toggleImageVisibility}
+          onEditVolume={handleEditVolume}
+          canEditVolume={canEditVolume}
+          onRemoveVolumeClick={handleRemoveVolumeClick}
+          onOpacityChange={handleOpacityChange}
+          onFrameChange={handleFrameChange}
+          onContrastMinChange={handleContrastMinChange}
+          onContrastMaxChange={handleContrastMaxChange}
+          onColormapChange={handleColormapChange}
+          onLabelVolumeChange={handleLabelVolumeChange}
+          onToggleSurfaceVisibility={toggleSurfaceVisibility}
+          onRemoveSurfaceClick={handleRemoveSurfaceClick}
+          onSurfaceOpacityChange={handleSurfaceOpacityChange}
+          onSurfaceColorChange={handleSurfaceColorChange}
+          onMeshShaderChange={handleMeshShaderChange}
+          getMeshShaderName={getMeshShaderName}
+          onCreateDrawingLayer={handleCreateDrawingLayer}
+          onDrawModeChange={handleDrawModeChange}
+          onPenFillChange={handlePenFillChange}
+          onPenErasesChange={handlePenErasesChange}
+          onPenValueChange={handlePenValueChange}
+          onDrawingOpacityChange={handleDrawingOpacityChange}
+          onMagicWand2dOnlyChange={handleMagicWand2dOnlyChange}
+          onMagicWandMaxDistanceChange={handleMagicWandMaxDistanceChange}
+          onMagicWandThresholdChange={handleMagicWandThresholdChange}
+          onDrawUndo={handleDrawUndo}
+          onSaveDrawing={handleSaveDrawing}
+          onSaveScene={handleSaveScene}
+        />
+      }
+      dialogs={
+        <>
+          <RemoveDialog
+            onConfirm={handleConfirmRemove}
+            onCancel={handleCancelRemove}
           />
-
-          {footerOpen && <Footer />}
-        </div>
-
-        {sidebarOpen && (
-          <Sidebar
+          <SaveDialog
             nvRef={nvRef}
-            serverlessMode={serverlessMode}
-            onNvdFileSelect={handleNvdFileSelect}
-            onImagingFileSelect={handleImagingFileSelect}
-            onAddMoreFiles={handleAddMoreFiles}
-            onAddSurfaceFiles={handleAddSurfaceFiles}
-            onToggleImageVisibility={toggleImageVisibility}
-            onEditVolume={handleEditVolume}
-            canEditVolume={canEditVolume}
-            onRemoveVolumeClick={handleRemoveVolumeClick}
-            onOpacityChange={handleOpacityChange}
-            onFrameChange={handleFrameChange}
-            onContrastMinChange={handleContrastMinChange}
-            onContrastMaxChange={handleContrastMaxChange}
-            onColormapChange={handleColormapChange}
-            onLabelVolumeChange={handleLabelVolumeChange}
-            onToggleSurfaceVisibility={toggleSurfaceVisibility}
-            onRemoveSurfaceClick={handleRemoveSurfaceClick}
-            onSurfaceOpacityChange={handleSurfaceOpacityChange}
-            onSurfaceColorChange={handleSurfaceColorChange}
-            onMeshShaderChange={handleMeshShaderChange}
-            getMeshShaderName={getMeshShaderName}
-            onCreateDrawingLayer={handleCreateDrawingLayer}
-            onDrawModeChange={handleDrawModeChange}
-            onPenFillChange={handlePenFillChange}
-            onPenErasesChange={handlePenErasesChange}
-            onPenValueChange={handlePenValueChange}
-            onDrawingOpacityChange={handleDrawingOpacityChange}
-            onMagicWand2dOnlyChange={handleMagicWand2dOnlyChange}
-            onMagicWandMaxDistanceChange={handleMagicWandMaxDistanceChange}
-            onMagicWandThresholdChange={handleMagicWandThresholdChange}
-            onDrawUndo={handleDrawUndo}
-            onSaveDrawing={handleSaveDrawing}
-            onSaveScene={handleSaveScene}
+            onConfirm={handleConfirmSave}
+            onCancel={handleCancelSave}
+            onVolumeUrlChange={handleVolumeUrlChange}
+            onVolumeCheckboxChange={handleVolumeCheckboxChange}
+            onDocumentLocationChange={handleDocumentLocationChange}
+            onDocumentCheckboxChange={handleDocumentCheckboxChange}
           />
-        )}
-      </div>
-
-      <input
-        type="file"
-        ref={fileInputRef}
-        onChange={handleFileChange}
-        multiple
-        className="hidden"
-      />
-      <input
-        type="file"
-        ref={surfaceFileInputRef}
-        onChange={handleSurfaceFileChange}
-        multiple
-        className="hidden"
-      />
-
-      <RemoveDialog
-        onConfirm={handleConfirmRemove}
-        onCancel={handleCancelRemove}
-      />
-      <SaveDialog
-        nvRef={nvRef}
-        onConfirm={handleConfirmSave}
-        onCancel={handleCancelSave}
-        onVolumeUrlChange={handleVolumeUrlChange}
-        onVolumeCheckboxChange={handleVolumeCheckboxChange}
-        onDocumentLocationChange={handleDocumentLocationChange}
-        onDocumentCheckboxChange={handleDocumentCheckboxChange}
-      />
-      <SettingsDialog nvRef={nvRef} />
-    </div>
+          <SettingsDialog nvRef={nvRef} />
+        </>
+      }
+      hiddenInputs={
+        <>
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            multiple
+            className="hidden"
+          />
+          <input
+            type="file"
+            ref={surfaceFileInputRef}
+            onChange={handleSurfaceFileChange}
+            multiple
+            className="hidden"
+          />
+        </>
+      }
+    />
   );
 }

--- a/frontend/src/components/image-uploader.tsx
+++ b/frontend/src/components/image-uploader.tsx
@@ -84,7 +84,6 @@ export default function ImageUploader({ onUpload, compact = false }: ImageUpload
         <div className="grid gap-1 text-center">
           <h3 className="text-lg font-semibold">Upload Medical Images</h3>
           <p className="text-sm text-muted-foreground">Drag and drop your medical images here or click to browse</p>
-          <p className="text-xs text-muted-foreground mt-2">Supported formats: NIfTI, GIfTI</p>
         </div>
         <Button onClick={handleButtonClick}>
           <Upload className="mr-2 h-4 w-4" />

--- a/frontend/src/components/qa-sidebar.tsx
+++ b/frontend/src/components/qa-sidebar.tsx
@@ -1,6 +1,7 @@
 import { ClipboardCheck } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import QaTab from "@/components/tabs/qa-tab";
 
 export default function QaSidebar() {
   return (
@@ -23,8 +24,8 @@ export default function QaSidebar() {
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="qa" className="flex-1 min-h-0 p-4">
-          <p className="text-sm text-muted-foreground">todo</p>
+        <TabsContent value="qa" className="flex-1 min-h-0 p-0">
+          <QaTab />
         </TabsContent>
       </Tabs>
     </aside>

--- a/frontend/src/components/qa-sidebar.tsx
+++ b/frontend/src/components/qa-sidebar.tsx
@@ -1,0 +1,32 @@
+import { ClipboardCheck } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+export default function QaSidebar() {
+  return (
+    <aside
+      className={cn(
+        "border-l bg-background w-80 overflow-hidden flex flex-col",
+      )}
+    >
+      <Tabs
+        defaultValue="qa"
+        className="flex flex-col flex-1 min-h-0"
+      >
+        <TabsList className="w-full justify-start border-b rounded-none px-2 h-12 flex-shrink-0">
+          <TabsTrigger
+            value="qa"
+            className="data-[state=active]:bg-muted"
+          >
+            <ClipboardCheck className="h-4 w-4 mr-2" />
+            QA
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="qa" className="flex-1 min-h-0 p-4">
+          <p className="text-sm text-muted-foreground">todo</p>
+        </TabsContent>
+      </Tabs>
+    </aside>
+  );
+}

--- a/frontend/src/components/qa-viewer.tsx
+++ b/frontend/src/components/qa-viewer.tsx
@@ -1,0 +1,73 @@
+import { useRef } from "react";
+import { useViewerOptions } from "@/hooks/use-viewer-options";
+import { useLocation } from "@/hooks/use-location";
+import { useVolumes } from "@/hooks/use-volumes";
+import { useFileLoading } from "@/hooks/use-file-loading";
+import { Niivue } from "@niivue/niivue";
+import { PanelRight } from "lucide-react";
+import "../App.css";
+import ViewerShell from "./viewer-shell";
+import QaSidebar from "./qa-sidebar";
+import SettingsDialog from "./dialogs/settings-dialog";
+
+const nv = new Niivue({
+  loadingText: "",
+  dragAndDropEnabled: false,
+  textHeight: 0.02,
+  backColor: [0, 0, 0, 1],
+  crosshairColor: [1.0, 0.88, 0.88, 1.0],
+  crosshairWidth: 0.3,
+  crosshairGap: 10,
+  multiplanarForceRender: false,
+});
+
+const noopSurface = () => {};
+
+export default function QaViewer() {
+  const nvRef = useRef<Niivue | null>(nv);
+
+  const {
+    viewerOptions,
+    applyViewerOptions,
+    syncViewerOptionsFromNiivue,
+    debouncedGLUpdate,
+  } = useViewerOptions(nvRef);
+  const { handleLocationChange } = useLocation(nvRef);
+  const { updateImageDetails } = useVolumes(
+    nvRef,
+    debouncedGLUpdate,
+    handleLocationChange,
+    noopSurface,
+  );
+  const {
+    fileInputRef,
+    handleFileUpload,
+    handleFileChange,
+  } = useFileLoading(
+    nvRef,
+    applyViewerOptions,
+    syncViewerOptionsFromNiivue,
+    updateImageDetails,
+    () => {},
+    handleLocationChange,
+    () => {},
+  );
+
+  return (
+    <ViewerShell
+      nvInstance={nv}
+      viewMode={viewerOptions.viewMode}
+      onFileUpload={handleFileUpload}
+      sidebar={<QaSidebar />}
+      dialogs={<SettingsDialog nvRef={nvRef} />}
+      nvCanvasEmptyState={
+        <div className="flex flex-col items-center justify-center gap-4 text-center max-w-xl mx-auto">
+          <div className="rounded-full bg-background p-3 shadow-sm">
+            <PanelRight className="h-10 w-10 text-muted-foreground" />
+          </div>
+          <p className="text-lg font-semibold">Initiate QA process using the sidebar on the right</p>
+        </div>
+      }
+    />
+  );
+}

--- a/frontend/src/components/tabs/qa-tab.tsx
+++ b/frontend/src/components/tabs/qa-tab.tsx
@@ -1,0 +1,7 @@
+export default function QaTab() {
+  return (
+    <div className="p-4">
+      <p className="text-sm text-muted-foreground">todo</p>
+    </div>
+  );
+}

--- a/frontend/src/components/viewer-shell.tsx
+++ b/frontend/src/components/viewer-shell.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { useFreeBrowseStore } from "@/store";
+import type { Niivue } from "@niivue/niivue";
+import type { ViewMode } from "@/store/types";
+import Header from "./header";
+import Footer from "./footer";
+import CanvasArea from "./canvas-area";
+
+interface ViewerShellProps {
+  nvInstance: Niivue;
+  viewMode: ViewMode;
+  onFileUpload: (files: File[]) => Promise<void>;
+  sidebar?: React.ReactNode;
+  dialogs?: React.ReactNode;
+  hiddenInputs?: React.ReactNode;
+  nvCanvasEmptyState?: React.ReactNode;
+}
+
+export default function ViewerShell({
+  nvInstance,
+  viewMode,
+  onFileUpload,
+  sidebar,
+  dialogs,
+  hiddenInputs,
+  nvCanvasEmptyState,
+}: ViewerShellProps) {
+  const sidebarOpen = useFreeBrowseStore((s) => s.sidebarOpen);
+  const footerOpen = useFreeBrowseStore((s) => s.footerOpen);
+  const darkMode = useFreeBrowseStore((s) => s.darkMode);
+
+  const nvRef = useRef<Niivue | null>(nvInstance);
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [darkMode]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <Header nvRef={nvRef} />
+
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 flex-col min-h-0">
+          <CanvasArea
+            nvInstance={nvInstance}
+            viewMode={viewMode}
+            onFileUpload={onFileUpload}
+            nvCanvasEmptyState={nvCanvasEmptyState}
+          />
+
+          {footerOpen && <Footer />}
+        </div>
+
+        {sidebarOpen && sidebar}
+      </div>
+
+      {hiddenInputs}
+      {dialogs}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, HashRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import FreeBrowse from './components/freebrowse.tsx';
+import QaViewer from './components/qa-viewer.tsx';
 
 // Get base path from Vite's base config (import.meta.env.BASE_URL)
 // This is automatically set by Vite based on the `base` config option
@@ -25,6 +26,15 @@ createRoot(document.getElementById('root')!).render(
            </div>
          </div>
       } />
+      {!isServerless && (
+        <Route path="/qa" element={
+          <div className="app-container">
+            <div className="main-content">
+              <QaViewer />
+            </div>
+          </div>
+        } />
+      )}
     </Routes>
   </Router>
   // </StrictMode>,


### PR DESCRIPTION
- Extracts shared viewer layout (header, canvas, footer, sidebar slot) into a reusable `ViewerShell` component so new UI variants can be created by composing existing pieces
- Adds `QaViewer` stub as the first alternate UI, accessible at `/qa` in default (full-stack) mode
- The `/qa` route is guarded behind `!isServerless` so it only appears in the full-stack build
- closes #14 