### PR TITLE
[DOC] fix link of FreeSurfer and FreeView

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 FreeBrowse is a full-stack, web-based neuroimaging viewer and editor.  It
 aspires to be a web-based version of the
-[FreeSurfer](surfer.nmr.mgh.harvard.edu) tool
-[FreeView](surfer.nmr.mgh.harvard.edu/fswiki/FreeviewGuide).
+[FreeSurfer](https://surfer.nmr.mgh.harvard.edu) tool
+[FreeView](https://surfer.nmr.mgh.harvard.edu/fswiki/FreeviewGuide).
 
 Try out the 'serverless' version: [https://freesurfer.github.io/freebrowse/](https://freesurfer.github.io/freebrowse/)
 


### PR DESCRIPTION
The links to FreeSurfer and FreeView in `README.md` are missing the `https://` prefix. Because of this, GitHub treats them as relative links and attempts to resolve them as files within the repository rather than external websites.

As a result, clicking the links leads to an incorrect location instead of the official project pages.
