### PR TITLE
Add a 'reset view' button

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freebrowse/frontend",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -8,6 +8,7 @@ import {
   Moon,
   Sun,
   Brain,
+  RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ViewSelector from "@/components/view-selector";
@@ -32,6 +33,7 @@ export default function Header({ nvRef }: HeaderProps) {
     viewerOptions,
     setViewerOptions,
     handleViewMode,
+    resetViewAndContrast,
   } = useViewerOptions(nvRef);
 
   return (
@@ -66,28 +68,35 @@ export default function Header({ nvRef }: HeaderProps) {
           <Button
             variant="outline"
             size="sm"
+            onClick={resetViewAndContrast}
+            className="h-8 w-8 p-0"
+            title="Reset view+contrast of all volumes"
+          >
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
             onClick={() => setSidebarOpen(!sidebarOpen)}
+            className="h-8 w-8 p-0"
+            title={sidebarOpen ? "Hide sidebar" : "Show sidebar"}
           >
             {sidebarOpen ? (
               <PanelRight className="h-4 w-4" />
             ) : (
               <PanelLeft className="h-4 w-4" />
             )}
-            <span className="ml-2 sr-only md:not-sr-only md:inline-block">
-              {/*sidebarOpen ? "Hide Sidebar" : "Show Sidebar"*/}
-            </span>
           </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={() => setFooterOpen(!footerOpen)}
+            className="h-8 w-8 p-0"
+            title={footerOpen ? "Hide footer" : "Show footer"}
           >
             <PanelBottom
               className={cn("h-4 w-4", !footerOpen && "rotate-180")}
             />
-            <span className="ml-2 sr-only md:not-sr-only md:inline-block">
-              {/*footerOpen ? "Hide Footer" : "Show Footer"*/}
-            </span>
           </Button>
           <Button
             variant="outline"
@@ -107,6 +116,7 @@ export default function Header({ nvRef }: HeaderProps) {
             size="sm"
             onClick={() => setSettingsDialogOpen(true)}
             className="h-8 w-8 p-0"
+            title="Settings"
           >
             <Settings className="h-4 w-4" />
           </Button>

--- a/frontend/src/hooks/use-viewer-options.ts
+++ b/frontend/src/hooks/use-viewer-options.ts
@@ -8,6 +8,7 @@ import type { ViewMode } from "@/store/types";
 export function useViewerOptions(nvRef: React.RefObject<Niivue | null>) {
   const viewerOptions = useFreeBrowseStore((s) => s.viewerOptions);
   const setViewerOptions = useFreeBrowseStore((s) => s.setViewerOptions);
+  const incrementVolumeVersion = useFreeBrowseStore((s) => s.incrementVolumeVersion);
 
   const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const crosshairColorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -226,6 +227,32 @@ export function useViewerOptions(nvRef: React.RefObject<Niivue | null>) {
     [nvRef, setViewerOptions, debouncedGLUpdate],
   );
 
+  // Reset zoom, centering, and 3D rotation of the view, plus the contrast of
+  // every volume, back to reasonable load-time defaults. Other viewer settings
+  // (drag mode, slice type, crosshair color, etc.) are intentionally untouched.
+  const resetViewAndContrast = useCallback(() => {
+    const nv = nvRef.current;
+    if (!nv) return;
+
+    // View: zoom + pan + crosshair centering (niivue INITIAL_SCENE_DATA defaults)
+    nv.scene.volScaleMultiplier = 1.0; // 3D zoom
+    nv.scene.pan2Dxyzmm = [0, 0, 0, 1]; // 2D pan + zoom
+    nv.scene.crosshairPos = [0.5, 0.5, 0.5]; // center (fractional coords)
+
+    // View: 3D rotation -> niivue defaults
+    nv.setRenderAzimuthElevation(110, 10);
+
+    // Contrast: every volume back to its robust (2-98%) range
+    for (const vol of nv.volumes ?? []) {
+      if (vol.robust_min !== undefined) vol.cal_min = vol.robust_min;
+      if (vol.robust_max !== undefined) vol.cal_max = vol.robust_max;
+    }
+
+    nv.updateGLVolume(); // re-render with new contrast
+    nv.drawScene(); // re-render the reset view
+    incrementVolumeVersion();
+  }, [nvRef, incrementVolumeVersion]);
+
   return {
     viewerOptions,
     setViewerOptions,
@@ -244,5 +271,6 @@ export function useViewerOptions(nvRef: React.RefObject<Niivue | null>) {
     handleColorbarChange,
     handleRadiologicalChange,
     handleSagittalNoseLeftChange,
+    resetViewAndContrast,
   };
 }


### PR DESCRIPTION
- Adds a reset button to the top right that when clicked resets the zoom, centering and contrast for all volumes 
- Also resets and 3D view.
- Also harmonizes the size of the (now five) buttons in top right corner
- Adds hover text to all five buttons
- Closes #30
- Bumps version to 2.4.4