### PR TITLE
Fixes responsiveness regression

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freebrowse/frontend",
   "private": true,
-  "version": "2.4.4",
+  "version": "2.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/freebrowse.tsx
+++ b/frontend/src/components/freebrowse.tsx
@@ -41,7 +41,7 @@ export default function FreeBrowse() {
     applyViewerOptions,
     syncViewerOptionsFromNiivue,
     debouncedGLUpdate,
-  } = useViewerOptions(nvRef);
+  } = useViewerOptions(nvRef, true);
   const { handleLocationChange } = useLocation(nvRef);
   const {
     updateSurfaceDetails,

--- a/frontend/src/components/qa-viewer.tsx
+++ b/frontend/src/components/qa-viewer.tsx
@@ -31,7 +31,7 @@ export default function QaViewer() {
     applyViewerOptions,
     syncViewerOptionsFromNiivue,
     debouncedGLUpdate,
-  } = useViewerOptions(nvRef);
+  } = useViewerOptions(nvRef, true);
   const { handleLocationChange } = useLocation(nvRef);
   useVolumes(
     nvRef,

--- a/frontend/src/hooks/use-viewer-options.ts
+++ b/frontend/src/hooks/use-viewer-options.ts
@@ -56,9 +56,22 @@ export function useViewerOptions(
       nvRef.current.opts.dragMode = DRAG_MODE[viewerOptions.dragMode];
       nvRef.current.overlayOutlineWidth = viewerOptions.overlayOutlineWidth;
       nvRef.current.opts.isColorbar = viewerOptions.isColorbar;
-      nvRef.current.setRadiologicalConvention(
-        viewerOptions.isRadiologicalConvention,
-      );
+      // setRadiologicalConvention() calls updateGLVolume() internally, which
+      // re-uploads every volume's 3D texture to the GPU — expensive.
+      // applyViewerOptions() runs on every viewer change (e.g. switching
+      // Axial/Coronal), so only call it when the value actually changed,
+      // otherwise each view click pays for a needless texture reload.
+      // NOTE: any other niivue call that internally triggers
+      // updateGLVolume()/refreshLayers() should be guarded the same way if
+      // added here in future.
+      if (
+        nvRef.current.opts.isRadiologicalConvention !==
+        viewerOptions.isRadiologicalConvention
+      ) {
+        nvRef.current.setRadiologicalConvention(
+          viewerOptions.isRadiologicalConvention,
+        );
+      }
       nvRef.current.opts.sagittalNoseLeft = viewerOptions.sagittalNoseLeft;
 
       if (viewConfig) {

--- a/frontend/src/hooks/use-viewer-options.ts
+++ b/frontend/src/hooks/use-viewer-options.ts
@@ -5,7 +5,10 @@ import { DRAG_MODE, type Niivue } from "@niivue/niivue";
 import type { DragMode } from "@/components/drag-mode-selector";
 import type { ViewMode } from "@/store/types";
 
-export function useViewerOptions(nvRef: React.RefObject<Niivue | null>) {
+export function useViewerOptions(
+  nvRef: React.RefObject<Niivue | null>,
+  autoApply = false,
+) {
   const viewerOptions = useFreeBrowseStore((s) => s.viewerOptions);
   const setViewerOptions = useFreeBrowseStore((s) => s.setViewerOptions);
   const incrementVolumeVersion = useFreeBrowseStore((s) => s.incrementVolumeVersion);
@@ -107,10 +110,12 @@ export function useViewerOptions(nvRef: React.RefObject<Niivue | null>) {
     }
   }, [nvRef, setViewerOptions]);
 
-  // Apply viewer options when they change
+  // Apply viewer options when they change — only in the component that owns
+  // nvRef, so each change is applied to niivue exactly once (this hook is used
+  // by several components that share the same nvRef).
   useEffect(() => {
-    applyViewerOptions();
-  }, [applyViewerOptions]);
+    if (autoApply) applyViewerOptions();
+  }, [applyViewerOptions, autoApply]);
 
   const handleViewMode = useCallback(
     (mode: ViewMode) => {


### PR DESCRIPTION
When clicking any of the 'View' or 'Right Drag' buttons, responsiveness was very slow.  This was due to 2 separate regressions
- The [hook refactor](https://github.com/freesurfer/freebrowse/commit/8cff3e38b1c3dc1bcdb1c1826850b15a5fa7fbc1) extracted viewer logic into the shared `useViewerOptions` hook meant its apply-on-change ran once per consumer (i.e 3 time)
- When adding [more settings](https://github.com/freesurfer/freebrowse/commit/aff766bd74439da73af07c54627a52b74e195ea7), `setRadiologicalConvention()` was added to `applyViewerOptions()` which caused an expensive unconditional `updateGLVolume()` after every viewer change (This was a much larger effect)

This PR:
- Applies viewer options once per change instead once per mounted `useViewerOptions` consumer
- Only calls `setRadiologicalConvention` when it changes, avoiding a GPU texture reload on every view click
- Closes #32
- Bumps version to 2.4.5