### PR TITLE
Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,42 @@ cd frontend
 npm run build
 ```
 
+### Deployment configuration (secure deployments)
+
+Some deployment settings are controlled at **build time** via Vite environment
+variables. These are operator-controlled and read-only at runtime (they are
+*not* user preferences).
+
+| Variable | Values | Effect |
+| --- | --- | --- |
+| `VITE_DISABLE_DOWNLOAD` | `true` / unset | Disables the **Download** button and no-ops niivue's save-to-disk methods (`saveImage`, `saveDocument`, `saveScene`, `saveHTML`, `saveToDisk`). For deploying into secure environments where local data export should be turned off. |
+| `VITE_SERVERLESS` | `true` / unset | Builds for the `file://` protocol with no backend (set automatically by `build:serverless`). Also disables the backend **Save** button. |
+| `VITE_BASE_PATH` | e.g. `/freebrowse/` | Base URL path for routing/assets. |
+
+`VITE_DISABLE_DOWNLOAD` is **env-driven and composes with every build target** —
+no build-script changes are needed. Just prepend it to whichever build you run:
+
+```bash
+# Static / serverless
+VITE_DISABLE_DOWNLOAD=true npm run build:serverless
+
+# JupyterLab embed
+VITE_DISABLE_DOWNLOAD=true npm run build:jupyter
+
+# GitHub Pages
+VITE_DISABLE_DOWNLOAD=true npm run build:github
+
+# Single standalone HTML file
+VITE_DISABLE_DOWNLOAD=true npm run build:singlefile
+
+# Full stack (with backend)
+VITE_DISABLE_DOWNLOAD=true npm run build
+```
+
+**Note:** this stops well-intentioned users from exporting data; it is *not* a
+guarantee against a malicious user, who can still read pixels from the GPU or
+intercept data via the browser console.
+
 ## Dev
 
 ### Run the backend in development mode
@@ -240,6 +276,15 @@ they become visible in Jupyter notebooks.
 ```bash
 cd frontend
 npm run build:jupyter
+```
+
+To embed FreeBrowse in a secure environment where data export is disabled, set
+`VITE_DISABLE_DOWNLOAD=true` for the build (see
+[Deployment configuration](#deployment-configuration-secure-deployments)):
+
+```bash
+cd frontend
+VITE_DISABLE_DOWNLOAD=true npm run build:jupyter
 ```
 
 To re-install the JupyterLab extensions:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,10 @@ RUN npm ci
 # Usage: docker build --build-arg SERVERLESS=true ...
 ARG SERVERLESS=false
 ENV VITE_SERVERLESS=${SERVERLESS}
+# Build argument to disable data export (Download button + niivue save-to-disk).
+# Usage: docker build --build-arg DISABLE_DOWNLOAD=true ...
+ARG DISABLE_DOWNLOAD=false
+ENV VITE_DISABLE_DOWNLOAD=${DISABLE_DOWNLOAD}
 RUN npm run build
 
 # Create data directory

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,28 @@ docker build -f docker/Dockerfile --build-arg SERVERLESS=true -t freebrowse:serv
 
 **Note:** Serverless mode is determined at build time. The `freebrowse:latest` image includes full backend support, while `freebrowse:serverless` is built without backend functionality (suitable for static file serving).
 
+### Disabling data export (secure deployments)
+
+To build an image where local data export is disabled (the **Download** button is
+disabled and niivue's save-to-disk methods are no-ops), pass the
+`DISABLE_DOWNLOAD=true` build arg. This is a **build-time** setting and composes
+with the serverless build arg:
+
+```bash
+# Server image with download disabled
+docker build -f docker/Dockerfile --build-arg DISABLE_DOWNLOAD=true -t freebrowse:secure .
+
+# Serverless image with download disabled
+docker build -f docker/Dockerfile \
+  --build-arg SERVERLESS=true --build-arg DISABLE_DOWNLOAD=true \
+  -t freebrowse:serverless-secure .
+```
+
+This stops well-intentioned users from exporting data; it is *not* a guarantee
+against a malicious user. See the main README's
+[Deployment configuration](../README.md#deployment-configuration-secure-deployments)
+section for details.
+
 ## Running with Docker
 
 ### Option 1: Localhost Only (Recommended for Security)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freebrowse/frontend",
   "private": true,
-  "version": "2.4.5",
+  "version": "2.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/tabs/scene-details-tab.tsx
+++ b/frontend/src/components/tabs/scene-details-tab.tsx
@@ -19,6 +19,7 @@ import { LabeledSliderWithInput } from "@/components/ui/labeled-slider-with-inpu
 import { Select } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
+import { deploymentConfig } from "@/lib/deployment-config";
 import type { Niivue } from "@niivue/niivue";
 
 interface SceneDetailsTabProps {
@@ -194,7 +195,14 @@ export default function SceneDetailsTab({
                 className="flex-1"
                 onClick={() => onSaveScene(true)}
                 disabled={
-                  volumes.length === 0 || drawingOptions.enabled
+                  volumes.length === 0 ||
+                  drawingOptions.enabled ||
+                  deploymentConfig.downloadDisabled
+                }
+                title={
+                  deploymentConfig.downloadDisabled
+                    ? "Download is disabled in this deployment"
+                    : undefined
                 }
               >
                 <Download className="mr-2 h-4 w-4" />

--- a/frontend/src/lib/deployment-config.ts
+++ b/frontend/src/lib/deployment-config.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-deployment configuration, resolved once at build time from Vite env vars.
+ *
+ * These are *deployment* (operator-controlled) settings, distinct from per-user
+ * preferences. They are read-only at runtime and must never be sourced from
+ * user-writable storage (localStorage, etc.).
+ *
+ * This module is the seed of the broader configuration framework (issue #34);
+ * a runtime config.json / backend override layer can be merged in here later.
+ */
+export const deploymentConfig = {
+  /** Serverless build (file:// protocol, no backend). */
+  serverless: import.meta.env.VITE_SERVERLESS === "true",
+  /**
+   * Lock down client-side data export for secure deployments: disables the
+   * Download button and no-ops niivue's save-to-disk methods. Not a guarantee
+   * against a determined/malicious user — it stops well-intentioned exports.
+   */
+  downloadDisabled: import.meta.env.VITE_DISABLE_DOWNLOAD === "true",
+} as const;

--- a/frontend/src/lib/disable-export.ts
+++ b/frontend/src/lib/disable-export.ts
@@ -1,0 +1,27 @@
+import { Niivue, NVImage } from "@niivue/niivue";
+
+/**
+ * Neutralize niivue's public save-to-disk API for secure deployments.
+ *
+ * Hiding the Download button stops the obvious path; this additionally no-ops
+ * the underlying niivue methods so a well-intentioned user poking the browser
+ * console (`nv.saveImage(...)`, `nv.volumes[0].saveToDisk(...)`, ...) doesn't
+ * trivially exfiltrate data. It is NOT a defense against a malicious user — the
+ * pixels are still on the GPU — it raises the bar for honest mistakes.
+ *
+ * Patched at the prototype level: there is effectively one Niivue instance, and
+ * this also covers the QA viewer and any volumes loaded later.
+ */
+export function applyExportLockdown(): void {
+  const emptyBytes = async (): Promise<Uint8Array> => new Uint8Array();
+
+  // Per-volume export (NVImage).
+  NVImage.prototype.saveToDisk = emptyBytes;
+  NVImage.prototype.saveToUint8Array = emptyBytes;
+
+  // Whole-instance export (Niivue).
+  Niivue.prototype.saveImage = async () => false;
+  Niivue.prototype.saveScene = async () => {};
+  Niivue.prototype.saveHTML = async () => {};
+  Niivue.prototype.saveDocument = async () => {};
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,13 @@ import { BrowserRouter, HashRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import FreeBrowse from './components/freebrowse.tsx';
 import QaViewer from './components/qa-viewer.tsx';
+import { deploymentConfig } from './lib/deployment-config';
+import { applyExportLockdown } from './lib/disable-export';
+
+// Secure deployments: neutralize niivue's save-to-disk API before the app mounts.
+if (deploymentConfig.downloadDisabled) {
+  applyExportLockdown();
+}
 
 // Get base path from Vite's base config (import.meta.env.BASE_URL)
 // This is automatically set by Vite based on the `base` config option

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import { createVolumeSlice, type VolumeSlice } from "./volume-slice";
 import { createSurfaceSlice, type SurfaceSlice } from "./surface-slice";
 import { createDrawingSlice, type DrawingSlice } from "./drawing-slice";
@@ -15,12 +16,33 @@ export type FreeBrowseStore = VolumeSlice &
   LocationSlice &
   AiSlice;
 
-export const useFreeBrowseStore = create<FreeBrowseStore>()((...a) => ({
-  ...createVolumeSlice(...a),
-  ...createSurfaceSlice(...a),
-  ...createDrawingSlice(...a),
-  ...createViewerSlice(...a),
-  ...createSaveSlice(...a),
-  ...createLocationSlice(...a),
-  ...createAiSlice(...a),
-}));
+export const useFreeBrowseStore = create<FreeBrowseStore>()(
+  persist(
+    (...a) => ({
+      ...createVolumeSlice(...a),
+      ...createSurfaceSlice(...a),
+      ...createDrawingSlice(...a),
+      ...createViewerSlice(...a),
+      ...createSaveSlice(...a),
+      ...createLocationSlice(...a),
+      ...createAiSlice(...a),
+    }),
+    {
+      name: "freebrowse-user-settings", // localStorage key
+      storage: createJSONStorage(() => localStorage),
+      version: 1, // bump + add migrate() on future schema changes
+      // Persist ONLY user preferences. Everything else — niivue viewerOptions,
+      // loaded volumes/surfaces, dialog-open flags, crosshair location, AI
+      // sessions, save state, version counters — is intentionally excluded so
+      // that e.g. a loaded document cannot hijack the user's defaults.
+      partialize: (state) => ({
+        skipRemoveConfirmation: state.skipRemoveConfirmation,
+        skipImagingUploadConfirmation: state.skipImagingUploadConfirmation,
+        skipSessionDeleteConfirmation: state.skipSessionDeleteConfirmation,
+        darkMode: state.darkMode,
+        sidebarOpen: state.sidebarOpen,
+        footerOpen: state.footerOpen,
+      }),
+    }
+  )
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,16 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;
+
+interface ImportMetaEnv {
+  /** Build serverless (file:// protocol, no backend). Set by build:serverless. */
+  readonly VITE_SERVERLESS?: string;
+  /** Base path for routing/assets (e.g. "/freebrowse/" for GitHub Pages). */
+  readonly VITE_BASE_PATH?: string;
+  /** When "true", disable the Download button and niivue save-to-disk (secure deployments). */
+  readonly VITE_DISABLE_DOWNLOAD?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
This PR:

- Facilitates secure deployments by:
  - Allowing a deployment to disable the download button via the `VITE_DISABLE_DOWNLOAD` env var
  - Disabling the following niivue functions:
    - `saveImage`
    - `saveScene`
    - `saveHTML`
    - `saveDocument`
    - Note that while this may prevent well-intentioned users from exfiltrating data, it may not stop a malicious user
- Persists the following user settings via [zustand persist](https://zustand.docs.pmnd.rs/reference/integrations/persisting-store-data)
  - `skipRemoveConfirmation`
  - `skipImagingUploadConfirmation`
  - `skipSessionDeleteConfirmation`
  - `darkMode`
  - `sidebarOpen`
  - `footerOpen`
  - Note: anything involving the niivue state is deliberately omitted, since this would result in unexpected behavior (e.g. a user opens a niivue document that changes the crosshair color.  This now becomes a persistent default)
- Paves the way for hotkey customization
- Closes #34 
- Bumps version to 2.4.6