### PR TITLE
Archive singlefile builds

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -10,7 +10,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write   # write (not read) so the release job can create tags + releases
   pages: write
   id-token: write
 
@@ -52,6 +52,14 @@ jobs:
           mkdir -p dist/downloads
           cp dist-singlefile/*.html dist/downloads/
 
+      - name: Upload single-file HTML as job artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebrowse-singlefile
+          path: frontend/dist-singlefile/freebrowse-*.html
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
@@ -70,3 +78,54 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Archive each version's single-file HTML as a GitHub Release asset so older
+  # versions remain downloadable for regression testing. Idempotent: skips if a
+  # release for the current frontend/package.json version already exists.
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read version from frontend/package.json
+        id: ver
+        working-directory: frontend
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release tag already exists
+        id: tagcheck
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git rev-parse "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1 \
+             || gh release view "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download single-file HTML artifact
+        if: steps.tagcheck.outputs.exists == 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: freebrowse-singlefile
+          path: release-assets
+
+      - name: Create GitHub Release with single-file asset
+        if: steps.tagcheck.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.ver.outputs.version }}
+          name: FreeBrowse v${{ steps.ver.outputs.version }}
+          body: |
+            Self-contained single-file build of FreeBrowse v${{ steps.ver.outputs.version }}.
+
+            Download `freebrowse-${{ steps.ver.outputs.version }}.html` and open it directly
+            (file://) or serve locally with `python3 -m http.server`.
+          files: release-assets/freebrowse-*.html
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -146,6 +146,42 @@ standalone HTML file is available at
 
 Where `<version>` is the [current version of freebrowse](https://github.com/freesurfer/freebrowse/blob/main/frontend/package.json#L4)
 
+The singlefile build is particularily useful with the python scripts in the
+[`scripts`](https://github.com/freesurfer/freebrowse/tree/main/scripts) directory
+to embed a niivue document and related imaging data directly into a the single
+HTML file.  The resulting HTML file can be used to visualize the output of
+processing pipelines, shared with collaborators and is offline compatible.  For
+a real-world example, see the [petsurfer-bids](https://github.com/freesurfer/petsurfer-bids)
+repository.
+
+#### Older versions
+
+The GitHub Pages site only ever hosts the **latest** single-file build (each
+deploy replaces the whole site).
+
+Every released version as of 2.4.7 is instead archived as a
+[GitHub Release](https://github.com/freesurfer/freebrowse/releases) with its
+standalone HTML attached as a release asset. This is the place to grab an older
+build to test for regressions. To download a specific version:
+
+```bash
+# Direct download URL (replace the version):
+# https://github.com/freesurfer/freebrowse/releases/download/v<version>/freebrowse-<version>.html
+
+# Or with the GitHub CLI:
+gh release download v2.4.7 --repo freesurfer/freebrowse --pattern 'freebrowse-*.html'
+```
+
+Then open the file directly (`file://`) or serve the containing folder locally:
+
+```bash
+python3 -m http.server
+# then browse to http://localhost:8000/freebrowse-2.4.6.html
+```
+
+Releases are created automatically by the deploy workflow whenever the
+`frontend/package.json` version is bumped on `main`.
+
 ### Full stack (with backend)
 
 Builds the frontend for use with the FastAPI backend:

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Then open the file directly (`file://`) or serve the containing folder locally:
 
 ```bash
 python3 -m http.server
-# then browse to http://localhost:8000/freebrowse-2.4.6.html
+# then browse to http://localhost:8000/freebrowse-2.4.7.html
 ```
 
 Releases are created automatically by the deploy workflow whenever the

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freebrowse/frontend",
   "private": true,
-  "version": "2.4.6",
+  "version": "2.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This PR:
- archives singlefile builds as github releases for regression testing
- closes #36
- bumps version to 2.4.7